### PR TITLE
Initial build 2.7.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels: 
-  - sfe1ed40
-channels:
-  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels: 
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  melody_org: fastai-2.7.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  melody_org: fastai-2.7.12
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 channels:
   melody_org: fastai-2.7.12
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastai" %}
-{% set version = "2.7.11" %}
+{% set version = "2.7.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/fastai-{{ version }}.tar.gz
-  sha256: c6b3a1766ac25afb0fb42143b2753189277ba31f8f8299ad7b92f234f0874585
+  sha256: e5ac80ff46dd8070c670a348f31a64c85ea1a91dc320c2106488f34333282916
 
 build:
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,13 +14,14 @@ build:
     - configure_accelerate=fastai.distributed:configure_accelerate
   # torchvision doesn't support python 3.11, s390x, or ppc64le
   skip: true  # [py<37 or py>310 or s390x or ppc64le]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
     - python
     - pip
+    - wheel
   run:
     - python
     - pip
@@ -50,8 +51,16 @@ test:
 about:
   home: https://github.com/fastai/fastai
   summary: fastai simplifies training fast and accurate neural nets using modern best practices
+  description: |
+    fastai is a deep learning library which provides practitioners with high-level components
+    that can quickly and easily provide state-of-the-art results in standard deep learning
+    domains, and provides researchers with low-level components that can be mixed and matched to
+    build new approaches.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  dev_url: https://github.com/fastai/fastai
+  doc_url: https://docs.fast.ai/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - pip
     - packaging
     - fastdownload >=0.0.5,<2
-    - fastcore >=1.4.5,<1.6
+    - fastcore >=1.5.29,<1.6
     - torchvision >=0.8.2
     - matplotlib-base
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - wheel
   run:
     - python
-    - pip
     - packaging
     - fastdownload >=0.0.5,<2
     - fastcore >=1.5.29,<1.6
@@ -38,7 +37,7 @@ requirements:
     - scikit-learn
     - scipy
     - spacy <4
-    - pytorch >=1.7,<1.14
+    - pytorch >=1.7,<2.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,17 @@ source:
 build:
   entry_points:
     - configure_accelerate=fastai.distributed:configure_accelerate
-  noarch: python
+  # torchvision doesn't support python 3.11, s390x, or ppc64le
+  skip: true  # [py<37 or py>310 or s390x or ppc64le]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
   run:
-    - python >=3.7
+    - python
     - pip
     - packaging
     - fastdownload >=0.0.5,<2


### PR DESCRIPTION
Jira: https://anaconda.atlassian.net/browse/PKG-2047
Upstream: https://github.com/fastai/fastai

❄️ Uploading to Snowflake channel.

- Python 3.11, ppc, and s390x are unsupported by `torchvision`, skipping those archs.
- Small adjustments to dependency pinnings to match upstream.
- `packaging` is included in run dependencies upstream.